### PR TITLE
Feat: Use separate model for embeddings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # ReaderHelp - AI Document Assistant
 
-ReaderHelp is a web-based tool that uses a local LLM (Gemma2:12b via Ollama) to help read and understand documents. It provides intelligent tools for document analysis, summarization, and question-answering through a beautiful, modern web interface.
+ReaderHelp is a web-based tool that uses local LLMs via Ollama to help read and understand documents. It uses a powerful generation model for chat and summarization, and a dedicated embedding model for document analysis. It provides intelligent tools for document analysis, summarization, and question-answering through a beautiful, modern web interface.
 
 ## Features
 
 - **Document Upload**: Support for PDF, DOCX, TXT, EPUB, and MD files
-- **AI-Powered Analysis**: Uses Gemma2:12b model for intelligent document understanding
+- **AI-Powered Analysis**: Uses a large language model for intelligent document understanding and a dedicated embedding model for high-quality retrieval.
 - **Interactive Chat**: Ask questions about your documents in natural language
 - **Document Summarization**: Generate comprehensive summaries of uploaded documents
 - **Quick Actions**: Pre-built questions for common document analysis tasks
@@ -18,7 +18,9 @@ Before running ReaderHelp, you need to have the following installed:
 
 1. **Python 3.8+**
 2. **Ollama** - [Installation Guide](https://ollama.ai/download)
-3. **Gemma2:12b Model** - Must be pulled in Ollama
+3. **Required Models** - The application requires two models to be pulled in Ollama:
+    - A **generation model** (e.g., `gemma3:12b`) for chat and summarization.
+    - An **embedding model** (e.g., `nomic-embed-text`) for document processing.
 
 ## Installation
 
@@ -38,22 +40,23 @@ pip install -r requirements.txt
 ### 3. Install and Setup Ollama
 
 1. Download and install Ollama from [ollama.ai](https://ollama.ai/download)
-2. Start Ollama service
-3. Pull the Gemma2:12b model:
+2. Start the Ollama service.
+3. Pull the required models. The default models are `gemma3:12b` and `nomic-embed-text`.
 
 ```bash
-ollama pull gemma2:12b
+ollama pull gemma3:12b
+ollama pull nomic-embed-text
 ```
 
 ### 4. Verify Ollama Setup
 
-Check that Ollama is running and the model is available:
+Check that Ollama is running and the models are available:
 
 ```bash
 ollama list
 ```
 
-You should see `gemma2:12b` in the list.
+You should see `gemma3:12b` and `nomic-embed-text` in the list.
 
 ## Usage
 
@@ -63,11 +66,11 @@ You should see `gemma2:12b` in the list.
 python app.py
 ```
 
-The application will start on `http://localhost:5000`
+The application will start on `http://localhost:5001` by default.
 
 ### 2. Upload a Document
 
-1. Open your web browser and navigate to `http://localhost:5000`
+1. Open your web browser and navigate to `http://localhost:5001`
 2. Drag and drop a document or click to browse and select a file
 3. Supported formats: PDF, DOCX, TXT, EPUB, MD
 4. Wait for the document to be processed (this may take a few moments for large files)
@@ -88,7 +91,7 @@ Once a document is uploaded, you can:
 - `POST /chat` - Send a question about the document
 - `POST /summarize` - Generate a document summary
 - `POST /clear` - Clear the current session
-- `GET /health` - Check Ollama status
+- `GET /health` - Check Ollama status and model availability.
 
 ## Project Structure
 
@@ -112,22 +115,31 @@ ReaderHelp/
 
 ### Environment Variables
 
-- `SECRET_KEY`: Flask secret key (defaults to development key)
-- `OLLAMA_HOST`: Ollama server host (defaults to localhost:11434)
+- `SECRET_KEY`: Flask secret key (defaults to a development key).
+- `OLLAMA_HOST`: Ollama server host (defaults to `localhost:11434`).
 
 ### Model Configuration
 
-The application is configured to use `gemma2:12b` by default. To use a different model:
+The application is configured to use two different models, which can be changed in `app.py`:
 
-1. Update the model name in `app.py`:
+- **`MODEL_NAME`**: The main language model for generation tasks like chat and summarization.
+- **`EMBEDDING_MODEL_NAME`**: The model used to generate embeddings for document retrieval.
+
+To use different models:
+
+1. Update the model names in `app.py`:
    ```python
-   llm = Ollama(model="your-model-name", request_timeout=120.0)
-   embed_model = OllamaEmbedding(model_name="your-model-name")
+   # The model for chat and summarization
+   MODEL_NAME = "your-generation-model"
+
+   # The model for creating embeddings
+   EMBEDDING_MODEL_NAME = "your-embedding-model"
    ```
 
-2. Ensure the model is available in Ollama:
+2. Ensure the models are available in Ollama:
    ```bash
-   ollama pull your-model-name
+   ollama pull your-generation-model
+   ollama pull your-embedding-model
    ```
 
 ## Troubleshooting
@@ -139,24 +151,29 @@ The application is configured to use `gemma2:12b` by default. To use a different
    - Check status: `ollama list`
 
 2. **Model not found**
-   - Pull the model: `ollama pull gemma2:12b`
+   - Pull the required models:
+     ```bash
+     ollama pull gemma3:12b
+     ollama pull nomic-embed-text
+     ```
    - Verify installation: `ollama list`
+   - Check the `/health` endpoint of the application.
 
 3. **Port already in use**
-   - Change the port in `app.py`:
+   - The application runs on port 5001 by default. If this port is taken, you can change it in `app.py`:
      ```python
-     app.run(debug=True, host='0.0.0.0', port=5001)
+     app.run(debug=True, host='0.0.0.0', port=5002)
      ```
 
 4. **Memory issues with large documents**
-   - The application processes documents in chunks
-   - For very large documents, consider splitting them into smaller files
+   - The application processes documents in chunks.
+   - For very large documents, consider splitting them into smaller files.
 
 ### Performance Tips
 
-- **RAM**: Gemma2:12b requires significant RAM (8GB+ recommended)
-- **GPU**: For better performance, ensure Ollama can use your GPU
-- **Document Size**: Large documents may take longer to process initially
+- **RAM**: The `gemma3:12b` model requires significant RAM (16GB+ recommended for good performance). The embedding model also consumes RAM.
+- **GPU**: For the best performance, ensure Ollama is configured to use your GPU.
+- **Document Size**: Large documents will take longer to process during the initial upload.
 
 ## Development
 
@@ -169,9 +186,9 @@ python app.py
 
 ### Adding New Features
 
-1. **New Document Types**: Add file extensions to `ALLOWED_EXTENSIONS` in `app.py`
-2. **New Chat Features**: Extend the `/chat` endpoint in `app.py`
-3. **UI Improvements**: Modify `templates/index.html` and `static/css/style.css`
+1. **New Document Types**: Add file extensions to `ALLOWED_EXTENSIONS` in `app.py`.
+2. **New Chat Features**: Extend the `/chat` endpoint in `app.py`.
+3. **UI Improvements**: Modify `templates/index.html` and `static/css/style.css`.
 
 ## Contributing
 
@@ -187,18 +204,18 @@ This project is licensed under the MIT License - see the LICENSE file for detail
 
 ## Acknowledgments
 
-- **LlamaIndex**: For the document processing and vector indexing capabilities
-- **Ollama**: For providing easy local LLM deployment
-- **Flask**: For the web framework
-- **Bootstrap**: For the responsive UI components
+- **LlamaIndex**: For the document processing and vector indexing capabilities.
+- **Ollama**: For providing easy local LLM deployment.
+- **Flask**: For the web framework.
+- **Bootstrap**: For the responsive UI components.
 
 ## Support
 
 If you encounter any issues:
 
-1. Check the troubleshooting section above
-2. Verify Ollama is running and the model is available
-3. Check the browser console for JavaScript errors
-4. Review the Flask application logs for Python errors
+1. Check the troubleshooting section above.
+2. Verify Ollama is running and the required models are available using `ollama list` and the `/health` endpoint.
+3. Check the browser console for JavaScript errors.
+4. Review the Flask application logs for Python errors.
 
 For additional support, please open an issue on the GitHub repository.

--- a/app.py
+++ b/app.py
@@ -16,6 +16,8 @@ app = Flask(__name__)
 app.secret_key = os.environ.get('SECRET_KEY', 'dev-secret-key-change-in-production')
 
 # Configuration
+MODEL_NAME = "gemma3:12b"
+EMBEDDING_MODEL_NAME = "nomic-embed-text"
 UPLOAD_FOLDER = 'static/uploads'
 ALLOWED_EXTENSIONS = {'txt', 'pdf', 'docx', 'epub', 'md'}
 app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
@@ -25,8 +27,8 @@ app.config['MAX_CONTENT_LENGTH'] = 50 * 1024 * 1024  # 50MB max file size
 os.makedirs(UPLOAD_FOLDER, exist_ok=True)
 
 # Initialize Ollama LLM and embeddings
-llm = Ollama(model="gemma3:12b", request_timeout=120.0)
-embed_model = OllamaEmbedding(model_name="gemma3:12b")
+llm = Ollama(model=MODEL_NAME, request_timeout=120.0)
+embed_model = OllamaEmbedding(model_name=EMBEDDING_MODEL_NAME)
 
 def allowed_file(filename):
     return '.' in filename and filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
@@ -212,26 +214,31 @@ def clear_session():
 
 @app.route('/health', methods=['GET'])
 def health_check():
-    """Check if Ollama is running and the model is available"""
+    """Check if Ollama is running and the required models are available"""
     try:
         import requests
         response = requests.get('http://localhost:11434/api/tags', timeout=5)
         if response.status_code == 200:
             models = response.json().get('models', [])
-            gemma_model = any('gemma2:12b' in model.get('name', '') for model in models)
+            model_names = [model.get('name', '') for model in models]
+            llm_model_available = any(MODEL_NAME in name for name in model_names)
+            embedding_model_available = any(EMBEDDING_MODEL_NAME in name for name in model_names)
             return jsonify({
                 'ollama_running': True,
-                'gemma_model_available': gemma_model
+                'llm_model_available': llm_model_available,
+                'embedding_model_available': embedding_model_available
             })
         else:
             return jsonify({
                 'ollama_running': False,
-                'gemma_model_available': False
+                'llm_model_available': False,
+                'embedding_model_available': False
             })
     except Exception as e:
         return jsonify({
             'ollama_running': False,
-            'gemma_model_available': False,
+            'llm_model_available': False,
+            'embedding_model_available': False,
             'error': str(e)
         })
 


### PR DESCRIPTION
The application was previously using the same model for both text generation and for creating embeddings. This caused an error because the `gemma3:12b` model does not support generating embeddings through the LlamaIndex `OllamaEmbedding` class.

This commit refactors the application to use two separate models:
- A powerful generation model (`gemma3:12b`) for chat and summarization.
- A dedicated embedding model (`nomic-embed-text`) for document processing and retrieval.

The following changes are included:
- `app.py` is updated with a new `EMBEDDING_MODEL_NAME` configuration variable.
- The `/health` endpoint now checks for the availability of both models.
- The `README.md` has been comprehensively updated to reflect the new two-model setup, including updated installation and configuration instructions.